### PR TITLE
Fix: Access Token 만료시간 24시간 설정

### DIFF
--- a/src/main/java/com/hanghae/code99/domain/Member.java
+++ b/src/main/java/com/hanghae/code99/domain/Member.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.List;
+import java.util.Random;
 
 @Entity
 @Getter
@@ -33,6 +34,8 @@ public class Member extends Timestamped {
     private String profilePic;
 
     private String introduce;
+    Random random = new Random();
+    private final String checkNum = String.valueOf(random.nextInt(888888) + 111111);
 
     private boolean status;
     @OneToMany(mappedBy = "room", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/hanghae/code99/domain/Member.java
+++ b/src/main/java/com/hanghae/code99/domain/Member.java
@@ -35,7 +35,6 @@ public class Member extends Timestamped {
 
     private String introduce;
     Random random = new Random();
-    private final String checkNum = String.valueOf(random.nextInt(888888) + 111111);
 
     private boolean status;
     @OneToMany(mappedBy = "room", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
@@ -45,7 +44,7 @@ public class Member extends Timestamped {
     private Member(String email, String password, String nickname, String profilePic) {
         this.email = email;
         this.password = password;
-        this.nickname = nickname;
+        this.nickname = nickname+"#"+ (random.nextInt(888888) + 111111);
         this.profilePic = profilePic;
         this.introduce = "";
     }

--- a/src/main/java/com/hanghae/code99/jwt/TokenProvider.java
+++ b/src/main/java/com/hanghae/code99/jwt/TokenProvider.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 @Component
 public class TokenProvider {
     private static final String BEARER_TYPE = "Bearer ";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;    // 30분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;    // 24시간
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 7일
 
     private final Key key;

--- a/src/main/java/com/hanghae/code99/service/MemberService.java
+++ b/src/main/java/com/hanghae/code99/service/MemberService.java
@@ -56,7 +56,7 @@ public class MemberService {
                 MemberResponseDto.builder()
                         .id(member.getMemberId())
                         .email(member.getEmail())
-                        .nickname(member.getNickname()+"#"+member.getCheckNum())
+                        .nickname(member.getNickname())
                         .createdAt(member.getCreatedAt())
                         .build());
     }
@@ -81,7 +81,7 @@ public class MemberService {
                 MemberResponseDto.builder()
                         .id(member.getMemberId())
                         .email(member.getEmail())
-                        .nickname(member.getNickname()+"#"+member.getCheckNum())
+                        .nickname(member.getNickname())
                         .createdAt(member.getCreatedAt())
                         .build()
         );
@@ -115,7 +115,7 @@ public class MemberService {
         return ResponseDto.success(MemberResponseDto.builder()
                 .id(member.getMemberId())
                 .email(member.getEmail())
-                .nickname(member.getNickname()+"#"+member.getCheckNum())
+                .nickname(member.getNickname())
                 .profilePic(member.getProfilePic())
                 .introduce(member.getIntroduce())
                 .createdAt(member.getCreatedAt())
@@ -166,7 +166,7 @@ public class MemberService {
             return ResponseDto.success(MemberResponseDto.builder()
                     .id(member.getMemberId())
                     .email(member.getEmail())
-                    .nickname(member.getNickname()+"#"+member.getCheckNum())
+                    .nickname(member.getNickname())
                     .profilePic(member.getProfilePic())
                     .introduce(member.getIntroduce())
                     .createdAt(member.getCreatedAt())

--- a/src/main/java/com/hanghae/code99/service/MemberService.java
+++ b/src/main/java/com/hanghae/code99/service/MemberService.java
@@ -56,7 +56,7 @@ public class MemberService {
                 MemberResponseDto.builder()
                         .id(member.getMemberId())
                         .email(member.getEmail())
-                        .nickname(member.getNickname())
+                        .nickname(member.getNickname()+"#"+member.getCheckNum())
                         .createdAt(member.getCreatedAt())
                         .build());
     }
@@ -81,7 +81,7 @@ public class MemberService {
                 MemberResponseDto.builder()
                         .id(member.getMemberId())
                         .email(member.getEmail())
-                        .nickname(member.getNickname())
+                        .nickname(member.getNickname()+"#"+member.getCheckNum())
                         .createdAt(member.getCreatedAt())
                         .build()
         );
@@ -115,7 +115,7 @@ public class MemberService {
         return ResponseDto.success(MemberResponseDto.builder()
                 .id(member.getMemberId())
                 .email(member.getEmail())
-                .nickname(member.getNickname())
+                .nickname(member.getNickname()+"#"+member.getCheckNum())
                 .profilePic(member.getProfilePic())
                 .introduce(member.getIntroduce())
                 .createdAt(member.getCreatedAt())
@@ -166,7 +166,7 @@ public class MemberService {
             return ResponseDto.success(MemberResponseDto.builder()
                     .id(member.getMemberId())
                     .email(member.getEmail())
-                    .nickname(member.getNickname())
+                    .nickname(member.getNickname()+"#"+member.getCheckNum())
                     .profilePic(member.getProfilePic())
                     .introduce(member.getIntroduce())
                     .createdAt(member.getCreatedAt())


### PR DESCRIPTION
## 어떤 것에 대한 PR인가요? :mag:
 프론트측의 요청으로  token reissue(재발급) 요청 없도록 Access Token 만료시간 24시간 설정

## 변경사항 :memo:

## 코멘트 :page_with_curl:
