### PR TITLE
Feat: hashtag 추가(고유 식별 번호)

### DIFF
--- a/src/main/java/com/hanghae/code99/configuration/SecurityConfig.java
+++ b/src/main/java/com/hanghae/code99/configuration/SecurityConfig.java
@@ -81,7 +81,6 @@ public class SecurityConfig {
                 .antMatchers(HttpMethod.POST, "/api/members/login").permitAll()
                 .antMatchers(HttpMethod.POST, "/api/members/signup").permitAll()
                 .antMatchers(HttpMethod.POST, "/api/members/check/email").permitAll()
-                .antMatchers(HttpMethod.POST, "/api/members/check/nick").permitAll()
                 .antMatchers(HttpMethod.GET, "/api/members/find/**").permitAll()
                 .antMatchers("/ws/chat").permitAll()
                 .antMatchers("/app/**").permitAll()

--- a/src/main/java/com/hanghae/code99/controller/MemberController.java
+++ b/src/main/java/com/hanghae/code99/controller/MemberController.java
@@ -60,11 +60,6 @@ public class MemberController {
         return memberService.checkDupEmail(requestDto);
     }
 
-    //닉네임 중복확인
-    @PostMapping("/api/members/check/nick")
-    public ResponseDto<?> nickCheck(@RequestBody @Valid NicknameCheckDto requestDto){
-        return memberService.checkDupNickname(requestDto);
-    }
 
     //내 프로필 조회
     @GetMapping("/api/auth/members/profiles")
@@ -79,16 +74,6 @@ public class MemberController {
     public ResponseDto<?> veiwProfile(@PathVariable Long memberId){
         return memberService.viewProfile(memberId);
     }
-//    @GetMapping("/api/auth/members/info")
-//    public ResponseDto<?> LoginInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
-//        Member member = userDetails.getMember();
-//
-//        try {
-//            return  memberService.LoginInfo(member);
-//        } catch (Exception e) {
-//            return  ResponseDto.fail("NOT_STATE_LOGIN", e.getMessage());
-//        }
-//    }
 
     //내 프로필 수정
     @PutMapping("/api/auth/members/profiles/edit")

--- a/src/main/java/com/hanghae/code99/controller/response/MemberResponseDto.java
+++ b/src/main/java/com/hanghae/code99/controller/response/MemberResponseDto.java
@@ -1,6 +1,5 @@
 package com.hanghae.code99.controller.response;
 
-import com.hanghae.code99.domain.Member;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,17 +17,20 @@ public class MemberResponseDto {
   private String nickname;
   private String profilePic;
   private String introduce;
+  private String hashtag;
   private LocalDateTime createdAt;
   private LocalDateTime modifiedAt;
 
 
 
-
-  public MemberResponseDto(Member member){
-    this.id = member.getMemberId();
-    this.email = member.getEmail();
-    this.nickname = member.getNickname();
-    this.profilePic = member.getProfilePic();
-    this.createdAt = member.getCreatedAt();
-  }
+//  public MemberResponseDto(Member member){
+//    this.id = member.getMemberId();
+//    this.email = member.getEmail();
+//    this.nickname = member.getNickname();
+//    this.profilePic = member.getProfilePic();
+//    this.introduce = member.getIntroduce();
+//    this.hashtag = member.getHashtag();
+//    this.createdAt = member.getCreatedAt();
+//    this.modifiedAt = member.getModifiedAt();
+//  }
 }

--- a/src/main/java/com/hanghae/code99/domain/Member.java
+++ b/src/main/java/com/hanghae/code99/domain/Member.java
@@ -1,9 +1,7 @@
 package com.hanghae.code99.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hanghae.code99.controller.request.ProfileRequestDto;
 import com.hanghae.code99.controller.request.SignUpRequestDto;
-import com.hanghae.code99.domain.message.Room;
 import com.hanghae.code99.domain.message.RoomMember;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -11,7 +9,6 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.List;
-import java.util.Random;
 
 @Entity
 @Getter
@@ -34,23 +31,24 @@ public class Member extends Timestamped {
     private String profilePic;
 
     private String introduce;
-    Random random = new Random();
 
+    private String hashtag;
     private boolean status;
     @OneToMany(mappedBy = "room", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RoomMember> roomList;
 
 
-    private Member(String email, String password, String nickname, String profilePic) {
+    private Member(String email, String password, String nickname, String profilePic, String hashtag) {
         this.email = email;
         this.password = password;
-        this.nickname = nickname+"#"+ (random.nextInt(888888) + 111111);
+        this.nickname = nickname;
         this.profilePic = profilePic;
+        this.hashtag = hashtag;
         this.introduce = "";
     }
 
-    public static Member of(SignUpRequestDto requestDto, String encodedPassword, String profilePic) {
-        return new Member(requestDto.getEmail(), encodedPassword, requestDto.getNickname(), profilePic);
+    public static Member of(SignUpRequestDto requestDto, String encodedPassword, String profilePic, String hashtag) {
+        return new Member(requestDto.getEmail(), encodedPassword, requestDto.getNickname(), profilePic, hashtag);
     }
 
     public void editProfile(ProfileRequestDto requestDto){

--- a/src/main/java/com/hanghae/code99/domain/Member.java
+++ b/src/main/java/com/hanghae/code99/domain/Member.java
@@ -1,5 +1,6 @@
 package com.hanghae.code99.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hanghae.code99.controller.request.ProfileRequestDto;
 import com.hanghae.code99.controller.request.SignUpRequestDto;
 import com.hanghae.code99.domain.message.RoomMember;

--- a/src/main/java/com/hanghae/code99/repositrory/MemberRepository.java
+++ b/src/main/java/com/hanghae/code99/repositrory/MemberRepository.java
@@ -7,8 +7,8 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
-    boolean existsByNickname(String nickname);
-    Optional<Member> findByEmail(String email);
 
+    Optional<Member> findByEmail(String email);
     Optional<Member> findByNickname(String nickname);
+    Optional<Member> findByHashtag(String hashtag);
 }


### PR DESCRIPTION
## 어떤 것에 대한 PR인가요? :mag:
hashtag라는 사용자별 고유 식별 번호를 만들어서
닉네임이 중복되더라도 고유 식별 번호로 구분 가능하도록 만들었습니다.

따라서 닉네임 중복 검증은 모두 삭제하였고
회원가입 시에 고유 식별번호를 999999 내에서 랜덤하게 부여하도록 설정했습니다.
고유 식별 번호가 중복되지 않도록 중복검증도 자동 실행합니다.(중복 시 재부여)

## 변경사항 :memo:
닉네임 중복 검증 관련 부분 모두 삭제

## 코멘트 :page_with_curl:
