### PR TITLE
Fix: 회원가입/로그인 시 response에 status 반환

### DIFF
--- a/src/main/java/com/hanghae/code99/controller/response/MemberResponseDto.java
+++ b/src/main/java/com/hanghae/code99/controller/response/MemberResponseDto.java
@@ -18,6 +18,7 @@ public class MemberResponseDto {
   private String profilePic;
   private String introduce;
   private String hashtag;
+  private boolean status;
   private LocalDateTime createdAt;
   private LocalDateTime modifiedAt;
 

--- a/src/main/java/com/hanghae/code99/service/MemberService.java
+++ b/src/main/java/com/hanghae/code99/service/MemberService.java
@@ -62,6 +62,7 @@ public class MemberService {
                         .profilePic(member.getProfilePic())
                         .introduce(member.getIntroduce())
                         .hashtag(member.getHashtag())
+                        .status(member.isStatus())
                         .createdAt(member.getCreatedAt())
                         .build());
     }
@@ -80,7 +81,12 @@ public class MemberService {
         JwtTokenDto tokenDto = tokenProvider.generateTokenDto(member);
         tokenToHeaders(tokenDto, response);
 
+        // 접속 중
         member.setStatus(true);
+        // DB에 status 업데이트
+        memberRepository.save(member);
+
+
 
         return ResponseDto.success(
                 MemberResponseDto.builder()
@@ -90,6 +96,7 @@ public class MemberService {
                         .profilePic(member.getProfilePic())
                         .introduce(member.getIntroduce())
                         .hashtag(member.getHashtag())
+                        .status(member.isStatus())
                         .createdAt(member.getCreatedAt())
                         .build()
         );
@@ -110,8 +117,10 @@ public class MemberService {
             return ResponseDto.fail("MEMBER_NOT_FOUND",
                     "사용자를 찾을 수 없습니다.");
         }
-
+        //접속 해제
         member.setStatus(false);
+        // DB에 status 업데이트
+        memberRepository.save(member);
 
         return tokenProvider.deleteRefreshToken(member);
     }
@@ -194,7 +203,6 @@ public class MemberService {
         Optional<Member> optionalMember = memberRepository.findByHashtag(hashtag);
         return optionalMember.orElse(null);
     }
-
 
 }
 


### PR DESCRIPTION
## 어떤 것에 대한 PR인가요? :mag:
프론트의 요청으로 회원가입/로그인 시, response에 status 추가

## 변경사항 :memo:
DB에 Status의 최신화가 되지 않는 것을 확인 후 수정 하였습니다.

## 코멘트 :page_with_curl:
